### PR TITLE
Should add functions for "Get Invite" and "Delete Invite" routes, fix minor issue in getChannelMessages.

### DIFF
--- a/src/main/kotlin/com/github/princesslana/smalldkt/http/Routes.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/http/Routes.kt
@@ -15,7 +15,9 @@ private val ioCoroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
 internal suspend fun <V> SmallD.get(path: String, resultSerializer: KSerializer<V>): V =
     suspendCoroutine { continuation ->
-        continuation.resume(JSON.parse(resultSerializer, get(path)))
+        val jsonRes = get(path)
+        println(jsonRes)
+        continuation.resume(JSON.parse(resultSerializer, jsonRes))
     }
 
 
@@ -95,10 +97,12 @@ internal suspend fun <V> SmallD.delete(path: String, resultSerializer: KSerializ
         Unit as V
     }
     else -> suspendCoroutine { continuation ->
+        val res = delete(path)
+        println(res)
         continuation.resume(
             JSON.parse(
                 resultSerializer,
-                delete(path)
+                res
             )
         )
     }

--- a/src/main/kotlin/com/github/princesslana/smalldkt/http/Routes.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/http/Routes.kt
@@ -15,9 +15,7 @@ private val ioCoroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
 internal suspend fun <V> SmallD.get(path: String, resultSerializer: KSerializer<V>): V =
     suspendCoroutine { continuation ->
-        val jsonRes = get(path)
-        println(jsonRes)
-        continuation.resume(JSON.parse(resultSerializer, jsonRes))
+        continuation.resume(JSON.parse(resultSerializer, get(path)))
     }
 
 
@@ -97,12 +95,10 @@ internal suspend fun <V> SmallD.delete(path: String, resultSerializer: KSerializ
         Unit as V
     }
     else -> suspendCoroutine { continuation ->
-        val res = delete(path)
-        println(res)
         continuation.resume(
             JSON.parse(
                 resultSerializer,
-                res
+                delete(path)
             )
         )
     }

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/channel/Requests.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/channel/Requests.kt
@@ -66,7 +66,7 @@ suspend fun SmallDData<*>.getChannelMessages(
     getChannelMessagesRequest: GetChannelMessagesRequest
 ): List<Channel> =
     smallD.get(
-        "/channels/$channelId/messages/${getChannelMessagesRequest.queryString}",
+        "/channels/$channelId/messages${getChannelMessagesRequest.queryString}",
         ArrayListSerializer(ChannelImpl.serializer())
     )
 

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/gateway/resources/PresenceUpdateEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/gateway/resources/PresenceUpdateEntity.kt
@@ -1,0 +1,149 @@
+package com.github.princesslana.smalldkt.type.gateway.resources
+
+import com.github.princesslana.smalldkt.type.Optional
+import com.github.princesslana.smalldkt.type.Snowflake
+import com.github.princesslana.smalldkt.type.user.user.PartialUserImpl
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
+
+
+interface ActivityTimeStamps{
+    val start: Int?
+    val end: Int?
+}
+
+@Serializable
+data class ActivityTimeStampsImpl(
+        override val start: Int? = null,
+        override val end: Int? = null
+): ActivityTimeStamps
+
+interface ActivityParty{
+    val id: String?
+    val size: List<Int>?
+}
+@Serializable
+data class ActivityPartyImpl(
+        override val id: String? = null,
+        override val size: List<Int>? = null
+): ActivityParty
+
+interface ActivityAssets{
+    val large_image: String?
+    val large_text: String?
+    val small_image: String?
+    val small_text: String?
+}
+
+@Serializable
+data class ActivityAssetsImpl(
+        override val large_image: String? = null,
+        override val large_text: String? = null,
+        override val small_image: String? = null,
+        override val small_text: String? = null
+): ActivityAssets
+
+interface ActivitySecrets{
+    val join: String?
+    val spectate: String?
+    val match: String?
+}
+
+@Serializable
+data class ActivitySecretsImpl(
+        override val join: String? = null,
+        override val spectate: String? = null,
+        override val match: String? = null
+): ActivitySecrets
+
+interface Activity{
+    val name: String
+    val type: ActivityType
+    val url: Optional<String>?
+    val timestamps: ActivityTimeStampsImpl?
+    val application_id: Snowflake?
+    val details: Optional<String>?
+    val state: Optional<String>?
+    val party: ActivityPartyImpl?
+    val assets: ActivityAssetsImpl?
+    val secrets: ActivitySecretsImpl?
+    val instance: Boolean?
+    val flags: Int?
+}
+
+@Serializable
+data class ActivityImpl(
+        override val name: String,
+        override val type: ActivityType,
+        override val url: Optional<String>? = Optional.absent(),
+        override val timestamps: ActivityTimeStampsImpl? = null,
+        override val application_id: Snowflake? = null,
+        override val details: Optional<String>? = Optional.absent(),
+        override val state: Optional<String>? = Optional.absent(),
+        override val party: ActivityPartyImpl? = null,
+        override val assets: ActivityAssetsImpl? = null,
+        override val secrets: ActivitySecretsImpl? = null,
+        override val instance: Boolean? = null,
+        override val flags: Int? = null
+): Activity
+
+interface ClientStatus{
+    val desktop: String?
+    val mobile: String?
+    val web: String?
+}
+
+@Serializable
+data class ClientStatusImpl(
+        override val desktop: String? = null,
+        override val mobile: String? = null,
+        override val web: String? = null
+): ClientStatus
+
+interface PartialPresenceUpdate{
+    val user: PartialUserImpl?
+    val roles: List<Snowflake>?
+    val game: Optional<ActivityImpl>?
+    val guild_id: Snowflake?
+    val status: String?
+    val activities: List<ActivityImpl>?
+    val client_status: ClientStatusImpl?
+}
+
+@Serializable
+data class PartialPresenceUpdateImpl(
+        override val user: PartialUserImpl? = null,
+        override val roles: List<Snowflake>? = null,
+        override val game: Optional<ActivityImpl>? = Optional.absent(),
+        override val guild_id: Snowflake? = null,
+        override val status: String? = null,
+        override val activities: List<ActivityImpl>? = null,
+        override val client_status: ClientStatusImpl? = null
+): PartialPresenceUpdate
+
+@Serializable(with = ActivityTypeSerializer::class)
+enum class ActivityType(val type: Int){
+    GAME(0),
+    STREAMING(1),
+    LISTENING(2)
+}
+
+
+@Serializer(forClass = ActivityType::class)
+class ActivityTypeSerializer : KSerializer<ActivityType> {
+
+    override val descriptor: SerialDescriptor = StringDescriptor.withName("ActivityTypeSerializer")
+
+    override fun deserialize(decoder: Decoder): ActivityType {
+        return when (decoder.decodeInt()) {
+            0 -> ActivityType.GAME
+            1 -> ActivityType.STREAMING
+            2 -> ActivityType.LISTENING
+            else -> throw IllegalStateException("Illegal Activity Type.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: ActivityType) {
+        encoder.encodeInt(obj.type)
+    }
+}

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/guild/resources/GuildEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/guild/resources/GuildEntity.kt
@@ -3,27 +3,119 @@ package com.github.princesslana.smalldkt.type.guild.resources
 import com.github.princesslana.smalldkt.type.Identifiable
 import com.github.princesslana.smalldkt.type.Optional
 import com.github.princesslana.smalldkt.type.Snowflake
+import com.github.princesslana.smalldkt.type.TimeStamp
+import com.github.princesslana.smalldkt.type.channel.resources.ChannelImpl
+import com.github.princesslana.smalldkt.type.emoji.resources.EmojiImpl
+import com.github.princesslana.smalldkt.type.gateway.resources.PartialPresenceUpdateImpl
+import com.github.princesslana.smalldkt.type.voice.resources.PartialVoiceStateImpl
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.StringDescriptor
 
-
-interface PartialGuild: Identifiable {
+interface Role: Identifiable{
     val name: String
-    val icon: String?
-    val splash: String?
-    val features: List<String>
-    val verification_level: VerificationLevel
-    val banner: String?
-    val vanity_url_code: String?
-    val description: String?
-    val owner: Optional<Boolean>
-    val permissions: Optional<Int>
-    val embed_enabled: Optional<Boolean>
-    val embed_channel_id: Optional<Snowflake>
-    val widget_enabled: Optional<Boolean>
-    val widget_channel_id: Optional<Snowflake>
-    val premium_subscription_count: Optional<Int>
+    val color: Int
+    val hoist: Boolean
+    val position: Int
+    val permissions: Int
+    val managed: Boolean
+    val mentionable: Boolean
 }
+
+@Serializable
+data class RoleImpl(
+        override val id: Snowflake,
+        override val name: String,
+        override val color: Int,
+        override val hoist: Boolean,
+        override val position: Int,
+        override val permissions: Int,
+        override val managed: Boolean,
+        override val mentionable: Boolean
+): Role
+
+interface PartialGuild{
+    val id: Snowflake?
+    val name: String?
+    val icon: Optional<String>?
+    val splash: Optional<String>?
+    val owner: Boolean?
+    val owner_id: Snowflake?
+    val permissions: Int?
+    val region: String?
+    val afk_channel_id: Optional<Snowflake>?
+    val afk_timeout: Int?
+    val embed_enabled: Boolean?
+    val embed_channel_id: Snowflake?
+    val verification_level: VerificationLevel?
+    val default_message_notifactions: Int?
+    val explicit_content_filter: Int?
+    val roles: List<RoleImpl>?
+    val emojis: List<EmojiImpl>?
+    val features: List<String>?
+    val mfa_level: MFALevel?
+    val application_id: Optional<Snowflake>?
+    val widget_enabled: Boolean?
+    val widget_channel_id: Snowflake?
+    val system_channel_id: Optional<Snowflake>?
+    val joined_at: TimeStamp?
+    val large: Boolean?
+    val unavailable: Boolean?
+    val member_count: Int?
+    val voice_states: List<PartialVoiceStateImpl>?
+    val members: List<GuildMemberImpl>?
+    val channels: List<ChannelImpl>?
+    val presences: List<PartialPresenceUpdateImpl>?
+    val max_presences: Optional<Int>?
+    val max_members: Int?
+    val vanity_url_code: Optional<String>?
+    val description: Optional<String>?
+    val banner: Optional<String>?
+    val premium_tier: PremiumTier?
+    val premium_subscription_count: Int?
+}
+
+@Serializable
+data class PartialGuildImpl(
+        override val id: Snowflake? = null,
+        override val name: String? = null,
+        override val icon: Optional<String>? = Optional.absent(),
+        override val splash: Optional<String>? = Optional.absent(),
+        override val owner: Boolean? = null,
+        override val owner_id: Snowflake? = null,
+        override val permissions: Int? = null,
+        override val region: String? = null,
+        override val afk_channel_id: Optional<Snowflake>? = Optional.absent(),
+        override val afk_timeout: Int? = null,
+        override val embed_enabled: Boolean? = null,
+        override val embed_channel_id: Snowflake? = null,
+        override val verification_level: VerificationLevel? = null,
+        override val default_message_notifactions: Int? = null,
+        override val explicit_content_filter: Int? = null,
+        override val roles: List<RoleImpl>? = null,
+        override val emojis: List<EmojiImpl>? = null,
+        override val features: List<String>? = null,
+        override val mfa_level: MFALevel? = null,
+        override val application_id: Optional<Snowflake>? = Optional.absent(),
+        override val widget_enabled: Boolean? = null,
+        override val widget_channel_id: Snowflake? = null,
+        override val system_channel_id: Optional<Snowflake>? = Optional.absent(),
+        override val joined_at: TimeStamp? = null,
+        override val large: Boolean? = null,
+        override val unavailable: Boolean? = null,
+        override val member_count: Int? = null,
+        override val voice_states: List<PartialVoiceStateImpl>? = null,
+        override val members: List<GuildMemberImpl>? = null,
+        override val channels: List<ChannelImpl>? = null,
+        override val presences: List<PartialPresenceUpdateImpl>? = null,
+        override val max_presences: Optional<Int>? = null,
+        override val max_members: Int? = null,
+        override val vanity_url_code: Optional<String>? = Optional.absent(),
+        override val description: Optional<String>? = Optional.absent(),
+        override val banner: Optional<String>? = Optional.absent(),
+        override val premium_tier: PremiumTier? = null,
+        override val premium_subscription_count: Int? = null
+): PartialGuild
+
 
 @Serializable(with = VerificationLevelSerializer::class)
 enum class VerificationLevel(val level: Int){
@@ -46,7 +138,7 @@ class VerificationLevelSerializer: KSerializer<VerificationLevel>{
             2 -> VerificationLevel.MEDIUM
             3 -> VerificationLevel.HIGH
             4 -> VerificationLevel.VERY_HIGH
-            else -> throw IllegalStateException("Illegal Target user type.")
+            else -> throw IllegalStateException("Illegal Verification level.")
         }
     }
 
@@ -55,22 +147,104 @@ class VerificationLevelSerializer: KSerializer<VerificationLevel>{
     }
 }
 
-@Serializable
-data class PartialGuildImpl(
-        override val name: String,
-        override val icon: String? = null,
-        override val splash: String? = null,
-        override val features: List<String>,
-        override val owner: Optional<Boolean> = Optional.absent(),
-        override val verification_level: VerificationLevel,
-        override val banner: String? = null,
-        override val vanity_url_code: String? = null,
-        override val description: String? = null,
-        override val id: Snowflake,
-        override val permissions: Optional<Int> = Optional.absent(),
-        override val embed_enabled: Optional<Boolean> = Optional.absent(),
-        override val embed_channel_id: Optional<Snowflake> = Optional.absent(),
-        override val widget_enabled: Optional<Boolean> = Optional.absent(),
-        override val widget_channel_id: Optional<Snowflake> = Optional.absent(),
-        override val premium_subscription_count: Optional<Int> = Optional.absent()
-): PartialGuild
+@Serializable(with = MFALevelSerializer::class)
+enum class MFALevel(val level: Int){
+    NONE(0),
+    ELEVATED(1)
+}
+
+@Serializer(forClass = MFALevel::class)
+class MFALevelSerializer: KSerializer<MFALevel>{
+    override val descriptor: SerialDescriptor =
+            StringDescriptor.withName("MFALevelSerializer")
+
+    override fun deserialize(decoder: Decoder): MFALevel {
+        return when(decoder.decodeInt()){
+            0 -> MFALevel.NONE
+            1 -> MFALevel.ELEVATED
+            else -> throw IllegalStateException("Illegal MFA Level.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: MFALevel) {
+        encoder.encodeInt(obj.level)
+    }
+}
+
+@Serializable(with = NotificationLevelSerializer::class)
+enum class NotificationLevel(val level: Int){
+    ALL_MESSAGES(0),
+    ONLY_MENTIONS(1)
+}
+
+@Serializer(forClass = NotificationLevel::class)
+class NotificationLevelSerializer: KSerializer<NotificationLevel>{
+    override val descriptor: SerialDescriptor =
+            StringDescriptor.withName("NotificationLevelSerializer")
+
+    override fun deserialize(decoder: Decoder): NotificationLevel {
+        return when(decoder.decodeInt()){
+            0 -> NotificationLevel.ALL_MESSAGES
+            1 -> NotificationLevel.ONLY_MENTIONS
+            else -> throw IllegalStateException("Illegal Notification Level.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: NotificationLevel) {
+        encoder.encodeInt(obj.level)
+    }
+}
+
+@Serializable(with = ExplicitContentFilterLevelSerializer::class)
+enum class ExplicitContentFilterLevel(val level: Int){
+    DISALED(0),
+    MEMBERS_WITOUT_ROLES(1),
+    ALL_MEMBERS(2)
+}
+
+@Serializer(forClass = ExplicitContentFilterLevel::class)
+class ExplicitContentFilterLevelSerializer: KSerializer<ExplicitContentFilterLevel>{
+    override val descriptor: SerialDescriptor =
+            StringDescriptor.withName("ExcplicitContentFilterLevelSerializer")
+
+    override fun deserialize(decoder: Decoder): ExplicitContentFilterLevel {
+        return when(decoder.decodeInt()){
+            0 -> ExplicitContentFilterLevel.DISALED
+            1 -> ExplicitContentFilterLevel.MEMBERS_WITOUT_ROLES
+            2 -> ExplicitContentFilterLevel.ALL_MEMBERS
+            else -> throw IllegalStateException("Illegal Content Filter Level.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: ExplicitContentFilterLevel) {
+        encoder.encodeInt(obj.level)
+    }
+}
+
+@Serializable(with = PremiumTierSerializer::class)
+enum class PremiumTier(val level: Int){
+    NONE(0),
+    TIER_1(1),
+    TIER_2(2),
+    TIER_3(3)
+}
+
+@Serializer(forClass = PremiumTier::class)
+class PremiumTierSerializer: KSerializer<PremiumTier>{
+    override val descriptor: SerialDescriptor =
+            StringDescriptor.withName("PremiumTierSerializer")
+
+    override fun deserialize(decoder: Decoder): PremiumTier {
+        return when(decoder.decodeInt()){
+            0 -> PremiumTier.NONE
+            1 -> PremiumTier.TIER_1
+            2 -> PremiumTier.TIER_2
+            3 -> PremiumTier.TIER_3
+            else -> throw IllegalStateException("Illegal Premium Tier.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: PremiumTier) {
+        encoder.encodeInt(obj.level)
+    }
+}

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/guild/resources/GuildEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/guild/resources/GuildEntity.kt
@@ -1,0 +1,76 @@
+package com.github.princesslana.smalldkt.type.guild.resources
+
+import com.github.princesslana.smalldkt.type.Identifiable
+import com.github.princesslana.smalldkt.type.Optional
+import com.github.princesslana.smalldkt.type.Snowflake
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
+
+
+interface PartialGuild: Identifiable {
+    val name: String
+    val icon: String?
+    val splash: String?
+    val features: List<String>
+    val verification_level: VerificationLevel
+    val banner: String?
+    val vanity_url_code: String?
+    val description: String?
+    val owner: Optional<Boolean>
+    val permissions: Optional<Int>
+    val embed_enabled: Optional<Boolean>
+    val embed_channel_id: Optional<Snowflake>
+    val widget_enabled: Optional<Boolean>
+    val widget_channel_id: Optional<Snowflake>
+    val premium_subscription_count: Optional<Int>
+}
+
+@Serializable(with = VerificationLevelSerializer::class)
+enum class VerificationLevel(val level: Int){
+    NONE(0),
+    LOW(1),
+    MEDIUM(2),
+    HIGH(3),
+    VERY_HIGH(4)
+}
+
+@Serializer(forClass = VerificationLevel::class)
+class VerificationLevelSerializer: KSerializer<VerificationLevel>{
+    override val descriptor: SerialDescriptor =
+            StringDescriptor.withName("VerificationLevelSerializer")
+
+    override fun deserialize(decoder: Decoder): VerificationLevel {
+        return when(decoder.decodeInt()){
+            0 -> VerificationLevel.NONE
+            1 -> VerificationLevel.LOW
+            2 -> VerificationLevel.MEDIUM
+            3 -> VerificationLevel.HIGH
+            4 -> VerificationLevel.VERY_HIGH
+            else -> throw IllegalStateException("Illegal Target user type.")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, obj: VerificationLevel) {
+        encoder.encodeInt(obj.level)
+    }
+}
+
+@Serializable
+data class PartialGuildImpl(
+        override val name: String,
+        override val icon: String? = null,
+        override val splash: String? = null,
+        override val features: List<String>,
+        override val owner: Optional<Boolean> = Optional.absent(),
+        override val verification_level: VerificationLevel,
+        override val banner: String? = null,
+        override val vanity_url_code: String? = null,
+        override val description: String? = null,
+        override val id: Snowflake,
+        override val permissions: Optional<Int> = Optional.absent(),
+        override val embed_enabled: Optional<Boolean> = Optional.absent(),
+        override val embed_channel_id: Optional<Snowflake> = Optional.absent(),
+        override val widget_enabled: Optional<Boolean> = Optional.absent(),
+        override val widget_channel_id: Optional<Snowflake> = Optional.absent(),
+        override val premium_subscription_count: Optional<Int> = Optional.absent()
+): PartialGuild

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
@@ -7,15 +7,14 @@ import com.github.princesslana.smalldkt.http.delete
 import com.github.princesslana.smalldkt.type.invite.resources.InviteData
 
 suspend fun SmallDData<*>.getInvite(code: String,includeCount: Boolean) =
-smallD.get(
-  "/invites/$code?" + queryString{
-    +("with_counts" to "$includeCount")
-  },
-  InviteData.serializer()
-)
+        smallD.get("/invites/$code" + queryString{
+            +("with_counts" to "$includeCount")
+        },
+                InviteData.serializer()
+        )
 
 suspend fun SmallDData<*>.deleteInvite(code: String) =
-smallD.delete(
-  "/invites/$code",
-  InviteData.serializer()
-)
+        smallD.delete(
+                "/invites/$code",
+                InviteData.serializer()
+        )

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
@@ -1,0 +1,21 @@
+package com.github.princesslana.smalldkt.type.invite
+
+import com.github.princesslana.smalldkt.SmallDData
+import com.github.princesslana.smalldkt.http.queryString
+import com.github.princesslana.smalldkt.http.get
+import com.github.princesslana.smalldkt.http.delete
+import com.github.princesslana.smalldkt.type.invite.resources.InviteData
+
+suspend fun SmallDData<*>.getInvite(code: String,includeCount: Boolean) =
+smallD.get(
+  "/invites/$code?" + queryString{
+    +("with_counts" to "$includeCount")
+  },
+  InviteData.serializer()
+)
+
+suspend fun SmallDData<*>.deleteInvite(code: String) =
+smallD.delete(
+  "/invites/$code",
+  InviteData.serializer()
+)

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/Requests.kt
@@ -4,17 +4,17 @@ import com.github.princesslana.smalldkt.SmallDData
 import com.github.princesslana.smalldkt.http.queryString
 import com.github.princesslana.smalldkt.http.get
 import com.github.princesslana.smalldkt.http.delete
-import com.github.princesslana.smalldkt.type.invite.resources.InviteData
+import com.github.princesslana.smalldkt.type.invite.resources.InviteImpl
 
 suspend fun SmallDData<*>.getInvite(code: String,includeCount: Boolean) =
         smallD.get("/invites/$code" + queryString{
             +("with_counts" to "$includeCount")
         },
-                InviteData.serializer()
+                InviteImpl.serializer()
         )
 
 suspend fun SmallDData<*>.deleteInvite(code: String) =
         smallD.delete(
                 "/invites/$code",
-                InviteData.serializer()
+                InviteImpl.serializer()
         )

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
@@ -10,23 +10,23 @@ import kotlinx.serialization.internal.StringDescriptor
 
 
 interface InviteMetadata{
-    val inviter: Optional<UserImpl>
-    val uses: Optional<Int>
-    val max_uses: Optional<Int>
-    val max_age: Optional<Int>
-    val temporary: Optional<Boolean>
-    val created_at: Optional<TimeStamp>
-    val revoked: Optional<Boolean>
+    val inviter: UserImpl?
+    val uses: Int?
+    val max_uses: Int?
+    val max_age: Int?
+    val temporary: Boolean?
+    val created_at: TimeStamp?
+    val revoked: Boolean?
 }
 
 interface Invite{
     val code: String
-    val guild: Optional<PartialGuildImpl>
+    val guild: PartialGuildImpl?
     val channel: ChannelImpl
-    val target_user: Optional<UserImpl>
-    val target_user_type: Optional<TargetUserType>
-    val approximate_presence_count: Optional<Int>
-    val approximate_member_count: Optional<Int>
+    val target_user: UserImpl?
+    val target_user_type: TargetUserType?
+    val approximate_presence_count: Int?
+    val approximate_member_count: Int?
 }
 
 @Serializable(with = TargetUserTypeSerializer::class)
@@ -51,17 +51,17 @@ class TargetUserTypeSerializer: KSerializer<TargetUserType>{
 @Serializable
 data class InviteImpl(
         override val code: String,
-        override val guild: Optional<PartialGuildImpl> = Optional.absent(),
+        override val guild: PartialGuildImpl? = null,
         override val channel: ChannelImpl,
-        override val target_user: Optional<UserImpl> = Optional.absent(),
-        override val target_user_type: Optional<TargetUserType> = Optional.absent(),
-        override val approximate_presence_count: Optional<Int> = Optional.absent(),
-        override val approximate_member_count: Optional<Int> = Optional.absent(),
-        override val inviter: Optional<UserImpl> = Optional.absent(),
-        override val uses: Optional<Int> = Optional.absent(),
-        override val max_uses: Optional<Int> = Optional.absent(),
-        override val max_age: Optional<Int> = Optional.absent(),
-        override val temporary: Optional<Boolean> = Optional.absent(),
-        override val created_at: Optional<TimeStamp> = Optional.absent(),
-        override val revoked: Optional<Boolean> = Optional.absent()
+        override val target_user: UserImpl? = null,
+        override val target_user_type: TargetUserType? = null,
+        override val approximate_presence_count: Int? = null,
+        override val approximate_member_count: Int? = null,
+        override val inviter: UserImpl? = null,
+        override val uses: Int? = null,
+        override val max_uses: Int? = null,
+        override val max_age: Int? = null,
+        override val temporary: Boolean? = null,
+        override val created_at: TimeStamp? = null,
+        override val revoked: Boolean? = null
 ): Invite,InviteMetadata

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
@@ -1,28 +1,67 @@
 package com.github.princesslana.smalldkt.type.invite.resources
 
-import com.github.princesslana.smalldkt.type.user.user.User
-import kotlinx.serialization.*
 import com.github.princesslana.smalldkt.type.channel.resources.*
-import kotlinx.serialization.Serializable
+import com.github.princesslana.smalldkt.type.Optional
+import com.github.princesslana.smalldkt.type.TimeStamp
+import com.github.princesslana.smalldkt.type.guild.resources.PartialGuildImpl
+import com.github.princesslana.smalldkt.type.user.user.UserImpl
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
 
+
+interface InviteMetadata{
+    val inviter: Optional<UserImpl>
+    val uses: Optional<Int>
+    val max_uses: Optional<Int>
+    val max_age: Optional<Int>
+    val temporary: Optional<Boolean>
+    val created_at: Optional<TimeStamp>
+    val revoked: Optional<Boolean>
+}
+
+interface Invite{
+    val code: String
+    val guild: Optional<PartialGuildImpl>
+    val channel: ChannelImpl
+    val target_user: Optional<UserImpl>
+    val target_user_type: Optional<TargetUserType>
+    val approximate_presence_count: Optional<Int>
+    val approximate_member_count: Optional<Int>
+}
+
+@Serializable(with = TargetUserTypeSerializer::class)
+enum class TargetUserType(val type: Int){
+    STREAM(1)
+}
+
+@Serializer(forClass = TargetUserType::class)
+class TargetUserTypeSerializer: KSerializer<TargetUserType>{
+    override val descriptor: SerialDescriptor = StringDescriptor.withName("TargetUserTypeSerializer")
+    override fun deserialize(decoder: Decoder): TargetUserType {
+        return when (decoder.decodeInt()){
+            1 -> TargetUserType.STREAM
+            else -> throw IllegalStateException("Illegal Target user type.")
+        }
+    }
+    override fun serialize(encoder: Encoder, obj: TargetUserType) {
+        encoder.encodeInt(obj.type)
+    }
+}
 
 @Serializable
-data class GuildObjectStub(
-        val splash: String?,
-        val features: List<String>,
-        val name: String,
-        val verification_level: Int,
-        val icon: String?,
-        val banner: String?,
-        val id: String,
-        val vanity_url_code: String?,
-        val description: String?
-)
-
-@Serializable
-data class InviteData(
-        val inviter: User,
-        val code: String,
-        val guild: GuildObjectStub,
-        val channel: Channel
-)
+data class InviteImpl(
+        override val code: String,
+        override val guild: Optional<PartialGuildImpl> = Optional.absent(),
+        override val channel: ChannelImpl,
+        override val target_user: Optional<UserImpl> = Optional.absent(),
+        override val target_user_type: Optional<TargetUserType> = Optional.absent(),
+        override val approximate_presence_count: Optional<Int> = Optional.absent(),
+        override val approximate_member_count: Optional<Int> = Optional.absent(),
+        override val inviter: Optional<UserImpl> = Optional.absent(),
+        override val uses: Optional<Int> = Optional.absent(),
+        override val max_uses: Optional<Int> = Optional.absent(),
+        override val max_age: Optional<Int> = Optional.absent(),
+        override val temporary: Optional<Boolean> = Optional.absent(),
+        override val created_at: Optional<TimeStamp> = Optional.absent(),
+        override val revoked: Optional<Boolean> = Optional.absent()
+): Invite,InviteMetadata

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/invite/resources/InviteEntity.kt
@@ -1,0 +1,28 @@
+package com.github.princesslana.smalldkt.type.invite.resources
+
+import com.github.princesslana.smalldkt.type.user.user.User
+import kotlinx.serialization.*
+import com.github.princesslana.smalldkt.type.channel.resources.*
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class GuildObjectStub(
+        val splash: String?,
+        val features: List<String>,
+        val name: String,
+        val verification_level: Int,
+        val icon: String?,
+        val banner: String?,
+        val id: String,
+        val vanity_url_code: String?,
+        val description: String?
+)
+
+@Serializable
+data class InviteData(
+        val inviter: User,
+        val code: String,
+        val guild: GuildObjectStub,
+        val channel: Channel
+)

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/user/user/UserEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/user/user/UserEntity.kt
@@ -1,9 +1,38 @@
 package com.github.princesslana.smalldkt.type.user.user
 
 import com.github.princesslana.smalldkt.type.Identifiable
+import com.github.princesslana.smalldkt.type.Optional
 import com.github.princesslana.smalldkt.type.Snowflake
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.StringDescriptor
+
+interface PartialUser: Identifiable{
+    val username: String?
+    val discriminator: String?
+    val avatar: Optional<String>?
+    val bot: Boolean?
+    val mfa_enabled: Boolean?
+    val locale: String?
+    val verified: Boolean?
+    val email: String?
+    val flags: Int?
+    val premium_type: PremiumType?
+}
+
+@Serializable
+data class PartialUserImpl(
+        override val id: Snowflake,
+        override val username: String? = null,
+        override val discriminator: String? = null,
+        override val avatar: Optional<String>? = Optional.absent(),
+        override val bot: Boolean? = null,
+        override val mfa_enabled: Boolean? = null,
+        override val locale: String? = null,
+        override val verified: Boolean? = null,
+        override val email: String? = null,
+        override val flags: Int? = null,
+        override val premium_type: PremiumType? = null
+): PartialUser
 
 @Serializable(with = UserImpl.`$serializer`::class)
 interface User : Identifiable {

--- a/src/main/kotlin/com/github/princesslana/smalldkt/type/voice/resources/VoiceStateEntity.kt
+++ b/src/main/kotlin/com/github/princesslana/smalldkt/type/voice/resources/VoiceStateEntity.kt
@@ -1,0 +1,60 @@
+package com.github.princesslana.smalldkt.type.voice.resources
+
+import com.github.princesslana.smalldkt.type.Optional
+import com.github.princesslana.smalldkt.type.Snowflake
+import com.github.princesslana.smalldkt.type.guild.resources.GuildMemberImpl
+import kotlinx.serialization.Serializable
+
+interface PartialVoiceState{
+    val guild_id: Snowflake?
+    val channel_id: Optional<Snowflake>?
+    val user_id: Snowflake?
+    val member: GuildMemberImpl?
+    val session_id: String?
+    val deaf: Boolean?
+    val mute: Boolean?
+    val self_deaf: Boolean?
+    val self_mute: Boolean?
+    val suppress: Boolean?
+}
+
+@Serializable
+data class PartialVoiceStateImpl(
+        override val guild_id: Snowflake? = null,
+        override val channel_id: Optional<Snowflake>? = null,
+        override val user_id: Snowflake? = null,
+        override val member: GuildMemberImpl? = null,
+        override val session_id: String? = null,
+        override val deaf: Boolean? = null,
+        override val mute: Boolean? = null,
+        override val self_deaf: Boolean? = null,
+        override val self_mute: Boolean? = null,
+        override val suppress: Boolean? = null
+): PartialVoiceState
+
+interface VoiceState{
+    val guild_id: Snowflake?
+    val channel_id: Snowflake?
+    val user_id: Snowflake
+    val member: GuildMemberImpl?
+    val session_id: String
+    val deaf: Boolean
+    val mute: Boolean
+    val self_deaf: Boolean
+    val self_mute: Boolean
+    val suppress: Boolean
+}
+
+@Serializable
+data class VoiceStateImpl(
+        override val guild_id: Snowflake? = null,
+        override val channel_id: Snowflake?,
+        override val user_id: Snowflake,
+        override val member: GuildMemberImpl? = null,
+        override val session_id: String,
+        override val deaf: Boolean,
+        override val mute: Boolean,
+        override val self_deaf: Boolean,
+        override val self_mute: Boolean,
+        override val suppress: Boolean
+):VoiceState


### PR DESCRIPTION
This will add the extensions functions 'getInvite' and 'deleteInvite' to the SmallDData<T> type, which correspond to the routes https://discordapp.com/developers/docs/resources/invite#get-invite and https://discordapp.com/developers/docs/resources/invite#delete-invite respectively. 

It also adds a data class to be used for storing the response for those paths. This class also makes use of a throwaway definition of a Guild object to make parsing the response easier, it should be able to be replaced easily with a more complete definition later if needed.